### PR TITLE
Restore Forge support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ version = GMUtils.updatingVersion(Versions.MOD)
 
 tasks.create("postDiscord") {
     val taskName = "publishCurseForge"
-    dependsOn(":fabric:${taskName}", /*":forge:${taskName}",*/ ":neoforge:${taskName}")
+    dependsOn(":fabric:${taskName}", ":forge:${taskName}", ":neoforge:${taskName}")
     doLast {
         try {
 
@@ -32,13 +32,13 @@ tasks.create("postDiscord") {
             val embed = Embed()
             val downloadSources = StringJoiner("\n")
 
-            mapOf(Pair("fabric", "<:fabric:932163720568782878>"),/* Pair("forge", "<:forge:932163698003443804>"), */Pair("neoforge", "<:neoforged:1184738260371644446>"))
+            mapOf(Pair("fabric", "<:fabric:932163720568782878>"), Pair("forge", "<:forge:932163698003443804>"), Pair("neoforge", "<:neoforged:1184738260371644446>"))
                     .filter {
                         project(":${it.key}").ext.has("curse_file_url")
                     }.map { "${it.value} [${it.key.capitalize(Locale.ENGLISH)}](${project(":${it.key}").ext.get("curse_file_url")})" }
                     .forEach { downloadSources.add(it) }
 
-            listOf("common", "fabric",/* "forge",*/ "neoforge")
+            listOf("common", "fabric", "forge", "neoforge")
                     .map { project(":${it}") }
                     .map { "<:maven:932165250738970634> `\"${it.group}:${it.base.archivesName.get()}:${it.version}\"`" }
                     .forEach { downloadSources.add(it) }

--- a/buildSrc/src/main/kotlin/blamejared-java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/blamejared-java-conventions.gradle.kts
@@ -84,7 +84,6 @@ tasks {
                 "FABRIC_LOADER" to Versions.FABRIC_LOADER,
                 "FABRIC" to Versions.FABRIC,
                 "FORGE" to Versions.FORGE,
-                "FORGE_LOADER" to Versions.FORGE_LOADER,
                 "NEO_FORGE" to Versions.NEO_FORGE,
                 "NEO_FORGE_LOADER" to Versions.NEO_FORGE_LOADER,
                 "GROUP" to Properties.GROUP,

--- a/buildSrc/src/main/kotlin/com/blamejared/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/blamejared/Versions.kt
@@ -6,8 +6,7 @@ object Versions {
     const val MINECRAFT = "1.21.1"
     const val FABRIC_LOADER = "0.15.11"
     const val FABRIC = "0.102.1+1.21.1"
-    const val FORGE = "49.0.19" // 1.20.4
-    const val FORGE_LOADER = "[49,)" // 1.20.4
+    const val FORGE = "52.0.15"
     const val NEO_FORGE = "21.1.8"
     const val NEO_FORGE_LOADER= "[4,)"
 }

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -1,24 +1,19 @@
-import com.blamejared.ambientenvironment.gradle.Properties
-import com.blamejared.ambientenvironment.gradle.Versions
+import com.blamejared.Properties
+import com.blamejared.Versions
 import com.blamejared.gradle.mod.utils.GMUtils
 import net.darkhax.curseforgegradle.TaskPublishCurseForge
-import net.darkhax.curseforgegradle.Constants as CFG_Constants
+import net.darkhax.curseforgegradle.Constants
 
 plugins {
-    id("com.blamejared.ambientenvironment.default")
-    id("com.blamejared.ambientenvironment.loader")
+    id("blamejared-modloader-conventions")
     id("net.minecraftforge.gradle") version ("[6.0,6.2)")
     id("org.spongepowered.mixin") version ("0.7-SNAPSHOT")
     id("com.modrinth.minotaur")
 }
 
-mixin {
-    add(sourceSets.main.get(), "${Properties.MODID}.refmap.json")
-    config("${Properties.MODID}.mixins.json")
-}
-
 minecraft {
     mappings("official", Versions.MINECRAFT)
+    reobf = false
     runs {
         create("client") {
             taskName("Client")
@@ -28,7 +23,6 @@ minecraft {
             mods {
                 create(Properties.MODID) {
                     source(sourceSets.main.get())
-                    source(project(":common").sourceSets.main.get())
                 }
             }
         }
@@ -37,8 +31,8 @@ minecraft {
 
 dependencies {
     "minecraft"("net.minecraftforge:forge:${Versions.MINECRAFT}-${Versions.FORGE}")
-    compileOnly(project(":common"))
-    annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
+    annotationProcessor("org.spongepowered:mixin:0.8.7-SNAPSHOT:processor")
+    implementation("net.sf.jopt-simple:jopt-simple:5.0.4") { version { strictly("5.0.4") } }
 }
 
 sourceSets.configureEach {
@@ -54,7 +48,7 @@ tasks.create<TaskPublishCurseForge>("publishCurseForge") {
     val mainFile = upload(Properties.CURSE_PROJECT_ID, tasks.jar.get().archiveFile)
     mainFile.changelogType = "markdown"
     mainFile.changelog = GMUtils.smallChangelog(project, Properties.GIT_REPO)
-    mainFile.releaseType = CFG_Constants.RELEASE_TYPE_RELEASE
+    mainFile.releaseType = Constants.RELEASE_TYPE_RELEASE
     mainFile.addJavaVersion("Java ${Versions.JAVA}")
     mainFile.addGameVersion(Versions.MINECRAFT)
 
@@ -71,5 +65,14 @@ modrinth {
     versionType.set("release")
     gameVersions.set(listOf(Versions.MINECRAFT))
     uploadFile.set(tasks.jar.get())
+    loaders.add("forge")
 }
 tasks.modrinth.get().dependsOn(tasks.jar)
+
+tasks {
+    named<Jar>("jar").configure {
+        manifest {
+            attributes["MixinConfigs"] = "${Properties.MODID}.mixins.json"
+        }
+    }
+}

--- a/forge/src/main/java/com/blamejared/ambientenvironment/AmbientEnvironment.java
+++ b/forge/src/main/java/com/blamejared/ambientenvironment/AmbientEnvironment.java
@@ -9,11 +9,10 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 @Mod("ambientenvironment")
 public class AmbientEnvironment {
     
-    public AmbientEnvironment() {
+    public AmbientEnvironment(FMLJavaModLoadingContext context) {
         
-        ModLoadingContext.get()
-                .registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> IExtensionPoint.DisplayTest.IGNORESERVERONLY, (remote, isServer) -> true));
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::doClientStuff);
+        context.registerDisplayTest(IExtensionPoint.DisplayTest.IGNORE_ALL_VERSION);
+        context.getModEventBus().addListener(this::doClientStuff);
     }
     
     private void doClientStuff(final FMLClientSetupEvent event) {

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "${FORGE_LOADER}"
+loaderVersion = "*"
 issueTrackerURL = "${GIT_REPO}/issues"
 license = "MIT"
 [[mods]]
@@ -14,7 +14,7 @@ itemIcon = "${ITEM_ICON}"
 [[dependencies.${MODID}]]
 modId = "forge"
 mandatory = true
-versionRange = "${FORGE_LOADER}"
+versionRange = "[${FORGE},)"
 ordering = "NONE"
 side = "BOTH"
 [[dependencies.${MODID}]]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,5 +17,5 @@ plugins {
 rootProject.name = "AmbientEnvironment"
 include("common")
 include("fabric")
-//include("forge")
+include("forge")
 include("neoforge")


### PR DESCRIPTION
This PR restores support for Forge 1.21.1.

It also takes advantage of newer Forge features, including:
- Simplified DisplayTest
- Context fed as a mod constructor param

Here's a screenshot of it working in production:
![2024-09-16_15 34 00](https://github.com/user-attachments/assets/ac6ee5d4-9d62-4c7a-a217-ce2cb7310399)
